### PR TITLE
fix: avoid preparing resourceclaim with multiple Pods in reversedFor

### DIFF
--- a/cmd/hami-kubelet-plugin/device_state.go
+++ b/cmd/hami-kubelet-plugin/device_state.go
@@ -156,6 +156,13 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	s.Lock()
 	defer s.Unlock()
 
+  if featuregates.Enabled(featuregates.HAMiCoreSupport) {
+		if len(claim.Status.ReservedFor) > 1 {
+			klog.Error("The claim can only be reservedFor a single Pod with HAMiCoreSupport enabled.")
+			return nil, fmt.Errorf("unable to prepare a claim with more than one Pods in reservedFor")
+		}
+  }
+
 	claimUID := string(claim.UID)
 
 	checkpoint, err := s.getCheckpoint()


### PR DESCRIPTION
## Description
ResourceClaim should not be allocated for multiple Pod when HAMiCoreSupport enables.

## Solution
So we add a check in `*DeviceState.Prepare` to avoid it.