### PR TITLE
Add granular DRA status authorization RBAC rules

### DIFF
--- a/demo/yaml/rbac.yaml
+++ b/demo/yaml/rbac.yaml
@@ -92,7 +92,16 @@ rules:
   resources:
   - resourceclaims/status
   verbs:
+  - get
   - update
+  - patch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/driver
+  verbs:
+  - associated-node:update
+  - associated-node:patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## Summary

- Add `resourceclaims/driver` permission with `associated-node:update` and `associated-node:patch` verbs to the ClusterRole in `demo/yaml/rbac.yaml`
- Add `get` and `patch` verbs to the existing `resourceclaims/status` rule for completeness

This prepares the driver for the `DRAResourceClaimGranularStatusAuthorization` feature gate, which is beta and on-by-default in Kubernetes v1.36. Since this is a node-local DRA driver (DaemonSet), the `associated-node:*` verbs are used. These permissions are inert on older Kubernetes versions.

Ref: kubernetes/kubernetes#138149